### PR TITLE
Add "shit list" license restrictions

### DIFF
--- a/PSeudo/PSeudo/LICENSE
+++ b/PSeudo/PSeudo/LICENSE
@@ -1,6 +1,23 @@
+Copyright 2021 Josh Holbrook
+
+The companies, organizations and individuals on this list; and subsidiaries of said
+companies, organizations or individuals; do not have a license to use this sofware:
+
+- Google and Alphabet - This is for many reasons, up to and including the
+  gutting of the Ethical AI team at Google, including the firings of
+  Timnit Gebru and Meg Mitchell
+- Facebook, for their irresponsible handling of false information and right
+  wing extremism on their platform especially following the 2016 presidential
+  election
+- GitHub, for their contracts with ICE
+
+This list overrides any license that may be granted by other portions of this
+software's licensing, excepting for when copyright disallows it.
+
+
 MIT License (Expat)
 
-Copyright (c) 2020 Josh Holbrook
+Copyright (c) 2021 Josh Holbrook
 Copyright (c) 2014 msumimz
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/PSeudo/PSeudo/PSeudo.psd1
+++ b/PSeudo/PSeudo/PSeudo.psd1
@@ -1,3 +1,20 @@
+# Copyright 2021 Josh Holbrook
+#
+# The companies, organizations and individuals on this list; and subsidiaries of said
+# companies, organizations or individuals; do not have a license to use this sofware:
+#
+# - Google and Alphabet - This is for many reasons, up to and including the
+#   gutting of the Ethical AI team at Google, including the firings of
+#   Timnit Gebru and Meg Mitchell
+# - Facebook, for their irresponsible handling of false information and right
+#   wing extremism on their platform especially following the 2016 presidential
+#   election
+# - GitHub, for their contracts with ICE
+#
+# This list overrides any license that may be granted by other portions of this
+# software's licensing, excepting for when copyright disallows it.
+#
+#
 # MIT License (Expat)
 #
 # Copyright (c) 2020 Josh Holbrook
@@ -26,7 +43,7 @@
   GUID = 'd540a6db-930e-4b14-bd04-4ed21eeed8c3'
   Author = 'Josh Holbrook'
   CompanyName = 'Josh Holbrook'
-  Copyright = 'Copyright 2020 Josh Holbrook. Copyright (c) 2014 msumimz. Licensed under an MIT/Expat license.'
+  Copyright = 'Copyright 2021 Josh Holbrook. Copyright (c) 2014 msumimz. Licensed under an MIT/Expat license with additional restrictions.'
   Description = 'Execute PowerShell commands as Administrator in Windows 10 "like sudo"'
 
   PowerShellVersion = '5.1'

--- a/PSeudo/PSeudo/PSeudo.psm1
+++ b/PSeudo/PSeudo/PSeudo.psm1
@@ -1,3 +1,20 @@
+# Copyright 2021 Josh Holbrook
+#
+# The companies, organizations and individuals on this list; and subsidiaries of said
+# companies, organizations or individuals; do not have a license to use this sofware:
+#
+# - Google and Alphabet - This is for many reasons, up to and including the
+#   gutting of the Ethical AI team at Google, including the firings of
+#   Timnit Gebru and Meg Mitchell
+# - Facebook, for their irresponsible handling of false information and right
+#   wing extremism on their platform especially following the 2016 presidential
+#   election
+# - GitHub, for their contracts with ICE
+#
+# This list overrides any license that may be granted by other portions of this
+# software's licensing, excepting for when copyright disallows it.
+#
+#
 # MIT License (Expat)
 #
 # Copyright (c) 2020 Josh Holbrook

--- a/PSeudo/README.md
+++ b/PSeudo/README.md
@@ -231,9 +231,26 @@ you know of a better strategy, *please* share.
 ## Licensing
 
 ```
+Copyright 2021 Josh Holbrook
+
+The companies, organizations and individuals on this list; and subsidiaries of said
+companies, organizations or individuals; do not have a license to use this sofware:
+
+- Google and Alphabet - This is for many reasons, up to and including the
+  gutting of the Ethical AI team at Google, including the firings of
+  Timnit Gebru and Meg Mitchell
+- Facebook, for their irresponsible handling of false information and right
+  wing extremism on their platform especially following the 2016 presidential
+  election
+- GitHub, for their contracts with ICE
+
+This list overrides any license that may be granted by other portions of this
+software's licensing, excepting for when copyright disallows it.
+
+
 MIT License (Expat)
 
-Copyright (c) 2020 Josh Holbrook
+Copyright (c) 2021 Josh Holbrook
 Copyright (c) 2014 msumimz
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -254,3 +271,4 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
+

--- a/README.org
+++ b/README.org
@@ -69,7 +69,8 @@ Anti-Capitalist Software License.
 ** PSeudo
 This is a PowerShell module for privilege escalation in Windows 10, using named
 pipes and a bunch of dirty tricks. It is based on code I found and saved from
-the internet. It is licensed under an MIT Expat license.
+the internet. It is licensed under an MIT Expat license with additional
+restrictions. See the LICENSE file for details.
 ** pyee
 This is a loose port of the Node.js EventEmitter with special support for
 coroutines and concurrent programming. It is licensed under an MIT license.

--- a/README.org
+++ b/README.org
@@ -21,10 +21,12 @@ student survey results for the University of Alaska Fairbanks from 2005 to 2009,
 in difficult-to-parse .pdf form. Sorry y'all.
 ** db_hooks
 This is the toolset I made for myself to manage database stuff on my personal
-machines. It is licensed under an Apache v2.0 license.
+machines. It is licensed under an Apache v2.0 license with additional
+restrictions. See the included NOTICE file for details.
 ** desktop
 This is stuff I'm working on for my Linux desktop. It is available under a MPL
-v2.0 license.
+v2.0 license with additional restrictions. See the included NOTICE files for
+details.
 ** github-profile
 This submodule contains my GitHub README profile. It is unlicensed but
 source-available.
@@ -47,10 +49,10 @@ remember something and want the source code let me know and I'll put it up.
 
 Most of these projects are licensed under a MIT/X11 license - if any of the
 licensing is unclear let me know.
-
 ** openscad
 These are files I've written for OpenSCAD. So far, these are available under a
-MPL v2.0 license.
+MPL v2.0 license with additional restrictions. See the included NOTICE file for
+details.
 ** politics
 These are projects I've done for political organizations.
 *** ak-demo-favicon
@@ -97,5 +99,7 @@ competition as you could trying to control a boat over hotel wifi. Sadly, I
 don't have pictures.
 ** twisted_ipython
 This is a module that makes autoawait work in IPython using Twisted. It is
-licened under a BSD 3-clause license. For more information, read [[https://dev.to/jfhbrook/twistedipython-autoawait-in-jupyter-notebooks-with-twisted-lee][the blog post
-on dev.to]].
+licened under a BSD 3-clause license with additional restrictions. See
+the included NOTICE file for details.
+
+For more information, read [[https://dev.to/jfhbrook/twistedipython-autoawait-in-jupyter-notebooks-with-twisted-lee][the blog post on dev.to]].

--- a/desktop/brightcli/NOTICE
+++ b/desktop/brightcli/NOTICE
@@ -1,6 +1,3 @@
-db_hooks
-Copyright 2021 Joshua Holbrook.
-
 The companies, organizations and individuals on this list; and subsidiaries of said
 companies, organizations or individuals; do not have a license to use this sofware:
 
@@ -14,5 +11,3 @@ companies, organizations or individuals; do not have a license to use this sofwa
 
 This list overrides any license that may be granted by other portions of this
 software's licensing, excepting for when copyright disallows it.
-
-Props to Josh Laurito and Allison Wentz, from whom I stole this idea.

--- a/desktop/brightcli/README.md
+++ b/desktop/brightcli/README.md
@@ -29,4 +29,5 @@ for hints, it's largely the same process.
 
 # license
 
-MIT :)
+This software is covered by the Mozilla Public License with additional
+restrictions. See the COPYING and NOTICE files for details.

--- a/desktop/korbenware/NOTICE
+++ b/desktop/korbenware/NOTICE
@@ -1,6 +1,3 @@
-db_hooks
-Copyright 2021 Joshua Holbrook.
-
 The companies, organizations and individuals on this list; and subsidiaries of said
 companies, organizations or individuals; do not have a license to use this sofware:
 
@@ -14,5 +11,3 @@ companies, organizations or individuals; do not have a license to use this sofwa
 
 This list overrides any license that may be granted by other portions of this
 software's licensing, excepting for when copyright disallows it.
-
-Props to Josh Laurito and Allison Wentz, from whom I stole this idea.

--- a/desktop/korbenware/README.org
+++ b/desktop/korbenware/README.org
@@ -40,8 +40,9 @@ come without these strings attached. Thanks for understanding.
 Pieces of this code are borrowed heavily from Click, Twisted and XInit itself;
 those pieces are licensed under a BSD 3-clause license in the case of the former
 and MIT licenses in the two latter. Everything I personally wrote is licensed
-under the Mozilla Public License v2.0. Each file is tagged with its individual
-license restrictions and the licenses themselves are included in the project.
+under the Mozilla Public License v2.0, with additional restrictions as outlined
+in the NOTICE file. Each file is tagged with its individual license restrictions
+and the licenses themselves are included in the project.
 * Various References
 ** [[https://wiki.lxde.org/en/LXSession#autostart_directories][XDG autostart support in lxde-lxsession]]
 ** [[https://specifications.freedesktop.org/autostart-spec/autostart-spec-0.5.html][The XDG autostart spec]]

--- a/twisted_ipython/NOTICE
+++ b/twisted_ipython/NOTICE
@@ -1,6 +1,3 @@
-db_hooks
-Copyright 2021 Joshua Holbrook.
-
 The companies, organizations and individuals on this list; and subsidiaries of said
 companies, organizations or individuals; do not have a license to use this sofware:
 
@@ -14,5 +11,3 @@ companies, organizations or individuals; do not have a license to use this sofwa
 
 This list overrides any license that may be granted by other portions of this
 software's licensing, excepting for when copyright disallows it.
-
-Props to Josh Laurito and Allison Wentz, from whom I stole this idea.

--- a/twisted_ipython/README.ipynb
+++ b/twisted_ipython/README.ipynb
@@ -597,7 +597,7 @@
         "\n",
         "## License\n",
         "\n",
-        "Like IPython, this is licensed under a 3-clause BSD license. For more, see `LICENSE.txt`."
+        "Like IPython, this is licensed under a 3-clause BSD license with additiona restrictions. For more, see the `LICENSE` and `NOTICE` files."
       ],
       "metadata": {}
     }

--- a/twisted_ipython/README.ipynb
+++ b/twisted_ipython/README.ipynb
@@ -597,7 +597,7 @@
         "\n",
         "## License\n",
         "\n",
-        "Like IPython, this is licensed under a 3-clause BSD license with additiona restrictions. For more, see the `LICENSE` and `NOTICE` files."
+        "Like IPython, this is licensed under a 3-clause BSD license with additional restrictions. For more, see the `LICENSE` and `NOTICE` files."
       ],
       "metadata": {}
     }


### PR DESCRIPTION
This pull request adds additional licensing restrictions to some of the software included in this repository, which disallow Google, Facebook or GitHub from using it.

I only covered a few projects. Many of the projects in this repository are inactive and I can't retroactively change the licensing of those projects. A handful - namely pyee - are in broad enough use that I don't have a full understanding of the ramifications of adding such restrictions. I would rather add these restrictions to software which isn't already in wide use. In addition, code covered by the GPL does not and will not have this restriction, since that software is intended to be Free Software. It's likely the liability of using GPL code is enough to keep these entities away from it anyway. Certain other licenses, including the anti-capitalist software license, are also considered sufficient on their own.

These restrictions have not been written by a lawyer, so I'd appreciate anybody with a good eye for legal-ese looking these over. I'm aware that parent companies of those mentioned in this list may still use the software - for instance, non-GH Microsoft companies may still use it if they wish.